### PR TITLE
Merge changes from original repository

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="555" id="org.phidatalab.radar_armt" ios-CFBundleIdentifier="org.phidatalab.radar-armt" ios-CFBundleVersion="1" version="1.1.0-alpha" xmlns:android="http://schemas.android.com/apk/res/android">
+<widget android-versionCode="556" id="org.phidatalab.radar_armt" ios-CFBundleIdentifier="org.phidatalab.radar-armt" ios-CFBundleVersion="1" version="1.2.0-alpha" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>RADAR Questionnaire</name>
     <description>An application that collects active data for research.</description>
     <author email="radar-base@kcl.ac.uk" href="http://radar-base.org/">RADAR-Base</author>

--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -304,6 +304,7 @@ export class ConfigService {
       this.subjectConfig
         .init(user)
         .then(() => this.analytics.setUserProperties(user))
+        .then(() => this.analytics.setUserProperties(user.attributes))
         .then(() => this.appConfig.init(user.enrolmentDate)),
       this.localization.init(),
       this.kafka.init(),

--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -281,6 +281,7 @@ export class ConfigService {
   resetAll() {
     this.sendConfigChangeEvent(ConfigEventType.APP_RESET)
     this.cancelNotifications()
+    this.notifications.unregisterFromNotificataions()
     return Promise.all([this.resetConfig(), this.resetCache()]).then(() =>
       this.subjectConfig.reset()
     )

--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -29,6 +29,8 @@ import { SubjectConfigService } from './subject-config.service'
 
 @Injectable()
 export class ConfigService {
+  ATTRIBUTE_KEY_PREFIX = 'att-'
+
   constructor(
     private schedule: ScheduleService,
     private notifications: NotificationService,
@@ -304,7 +306,12 @@ export class ConfigService {
       this.subjectConfig
         .init(user)
         .then(() => this.analytics.setUserProperties(user))
-        .then(() => this.analytics.setUserProperties(user.attributes))
+        .then(() =>
+          this.analytics.setUserProperties(
+            user.attributes,
+            this.ATTRIBUTE_KEY_PREFIX
+          )
+        )
         .then(() => this.appConfig.init(user.enrolmentDate)),
       this.localization.init(),
       this.kafka.init(),

--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -305,9 +305,8 @@ export class ConfigService {
         .then(() => this.analytics.setUserProperties(user))
         .then(() => this.appConfig.init(user.enrolmentDate)),
       this.localization.init(),
-      this.kafka.init(),
-      this.notifications.init()
-    ])
+      this.kafka.init()
+    ]).then(() => this.notifications.init())
   }
 
   getAll() {

--- a/src/app/core/services/config/protocol.service.spec.ts
+++ b/src/app/core/services/config/protocol.service.spec.ts
@@ -2,11 +2,13 @@ import { HttpClient, HttpHandler } from '@angular/common/http'
 import { TestBed } from '@angular/core/testing'
 
 import {
+  FirebaseAnalyticsServiceMock,
   LogServiceMock,
   RemoteConfigServiceMock,
   SubjectConfigServiceMock
 } from '../../../shared/testing/mock-services'
 import { LogService } from '../misc/log.service'
+import { AnalyticsService } from '../usage/analytics.service'
 import { ProtocolService } from './protocol.service'
 import { RemoteConfigService } from './remote-config.service'
 import { SubjectConfigService } from './subject-config.service'
@@ -22,7 +24,11 @@ describe('ProtocolService', () => {
         HttpHandler,
         { provide: SubjectConfigService, useClass: SubjectConfigServiceMock },
         { provide: RemoteConfigService, useClass: RemoteConfigServiceMock },
-        { provide: LogService, useClass: LogServiceMock }
+        { provide: LogService, useClass: LogServiceMock },
+        {
+          provide: AnalyticsService,
+          useClass: FirebaseAnalyticsServiceMock
+        }
       ]
     })
   )

--- a/src/app/core/services/config/protocol.service.ts
+++ b/src/app/core/services/config/protocol.service.ts
@@ -21,6 +21,7 @@ import {
 import { ProtocolMetaData } from '../../../shared/models/protocol'
 import { sortObject } from '../../../shared/utilities/sort-object'
 import { LogService } from '../misc/log.service'
+import { AnalyticsService } from '../usage/analytics.service'
 import { RemoteConfigService } from './remote-config.service'
 import { SubjectConfigService } from './subject-config.service'
 
@@ -34,7 +35,8 @@ export class ProtocolService {
     private config: SubjectConfigService,
     private http: HttpClient,
     private remoteConfig: RemoteConfigService,
-    private logger: LogService
+    private logger: LogService,
+    private analytics: AnalyticsService
   ) {}
 
   pull(): Promise<ProtocolMetaData> {
@@ -179,21 +181,21 @@ export class ProtocolService {
       .then(cfg =>
         Promise.all([
           this.config.getParticipantAttributes(),
+          this.config.pullSubjectInformation(),
           this.getParticipantAttributeOrder(cfg)
         ])
       )
-      .then(([attributes, order]) => {
-        return new Promise(resolve => {
-          if (attributes == null)
-            this.config.pullSubjectInformation().then(user => {
-              this.config.setParticipantAttributes(user.attributes)
-              resolve((attributes = user.attributes))
-            })
-          else resolve()
-        }).then(() => {
-          const orderWithoutNull = this.formatAttributeOrder(attributes, order)
-          return sortObject(attributes, orderWithoutNull)
-        })
+      .then(([attributes, user, order]) => {
+        const newAttributes =
+          JSON.stringify(attributes) == JSON.stringify(user.attributes)
+            ? attributes
+            : user.attributes
+        this.config.setParticipantAttributes(newAttributes)
+        this.analytics.setUserProperties(newAttributes)
+        return sortObject(
+          newAttributes,
+          this.formatAttributeOrder(newAttributes, order)
+        )
       })
   }
 

--- a/src/app/core/services/notifications/fcm-notification.service.spec.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing'
 import { FirebaseX } from '@ionic-native/firebase-x/ngx'
 import { Platform } from 'ionic-angular'
-import { PlatformMock } from 'ionic-mocks'
 
 import {
   FirebaseMock,
@@ -29,7 +28,7 @@ describe('FcmNotificationService', () => {
     TestBed.configureTestingModule({
       providers: [
         FcmNotificationService,
-        { provide: Platform, useClass: PlatformMock },
+        Platform,
         { provide: FirebaseX, useClass: FirebaseMock },
         { provide: LogService, useClass: LogServiceMock },
         { provide: StorageService, useClass: StorageServiceMock },
@@ -47,6 +46,8 @@ describe('FcmNotificationService', () => {
 
   beforeEach(() => {
     service = TestBed.get(FcmNotificationService)
+    const platform = TestBed.get(Platform)
+    spyOn(platform, 'ready').and.callFake(() => Promise.resolve(''))
   })
 
   it('should create', () => {

--- a/src/app/core/services/notifications/fcm-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.ts
@@ -34,16 +34,18 @@ export abstract class FcmNotificationService extends NotificationService {
     public remoteConfig: RemoteConfigService
   ) {
     super(store)
-    this.remoteConfig.subject().subscribe(cfg => {
-      cfg
-        .getOrDefault(
-          ConfigKeys.NOTIFICATION_TTL_MINUTES,
-          String(this.ttlMinutes)
-        )
-        .then(
-          ttl =>
-            (this.ttlMinutes = Number(ttl) || DefaultNotificationTtlMinutes)
-        )
+    this.platform.ready().then(() => {
+      this.remoteConfig.subject().subscribe(cfg => {
+        cfg
+          .getOrDefault(
+            ConfigKeys.NOTIFICATION_TTL_MINUTES,
+            String(this.ttlMinutes)
+          )
+          .then(
+            ttl =>
+              (this.ttlMinutes = Number(ttl) || DefaultNotificationTtlMinutes)
+          )
+      })
     })
   }
 

--- a/src/app/core/services/notifications/fcm-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.ts
@@ -50,6 +50,7 @@ export abstract class FcmNotificationService extends NotificationService {
   }
 
   init() {
+    this.firebase.setAutoInitEnabled(true)
     if (!this.platform.is('ios'))
       FirebasePlugin.setDeliveryMetricsExportToBigQuery(true)
     FirebasePlugin.setSenderId(
@@ -110,6 +111,13 @@ export abstract class FcmNotificationService extends NotificationService {
     return timeUntilEnd > 0
       ? getSeconds({ milliseconds: timeUntilEnd })
       : getSeconds({ minutes: this.ttlMinutes })
+  }
+
+  unregisterFromNotificataions(): Promise<any> {
+    // NOTE: This will delete the current device token and stop receiving notifications
+    return this.firebase
+      .setAutoInitEnabled(false)
+      .then(() => this.firebase.unregister())
   }
 
   abstract getSubjectDetails()

--- a/src/app/core/services/notifications/fcm-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.ts
@@ -61,11 +61,10 @@ export abstract class FcmNotificationService extends NotificationService {
         alert(error)
       }
     )
-    this.firebase.getToken().then(token => {
-      this.FCM_TOKEN = token
-      this.setFCMToken(token)
-      this.logger.log('[NOTIFICATION SERVICE] Refresh token success')
-    })
+    this.firebase
+      .onTokenRefresh()
+      .subscribe(token => this.onTokenRefresh(token))
+    this.firebase.getToken().then(token => this.onTokenRefresh(token))
   }
 
   publish(
@@ -118,6 +117,14 @@ export abstract class FcmNotificationService extends NotificationService {
     return this.firebase
       .setAutoInitEnabled(false)
       .then(() => this.firebase.unregister())
+  }
+
+  onTokenRefresh(token) {
+    if (token) {
+      this.FCM_TOKEN = token
+      this.setFCMToken(token)
+      this.logger.log('[NOTIFICATION SERVICE] Refresh token success')
+    }
   }
 
   abstract getSubjectDetails()

--- a/src/app/core/services/notifications/fcm-rest-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-rest-notification.service.ts
@@ -224,6 +224,7 @@ export class FcmRestNotificationService extends FcmNotificationService {
           return res.body
         })
         .catch((err: HttpErrorResponse) => {
+          this.logger.log('Http request returned an error: ' + err.message)
           const data: FcmNotificationError = err.error
           if (err.status == 409) {
             this.logger.log(

--- a/src/app/core/services/notifications/fcm-rest-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-rest-notification.service.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../assets/data/defaultConfig'
 import {
   FcmNotificationDto,
+  FcmNotificationError,
   FcmNotifications
 } from '../../../shared/models/app-server'
 import { AssessmentType } from '../../../shared/models/assessment'
@@ -223,12 +224,19 @@ export class FcmRestNotificationService extends FcmNotificationService {
           return res.body
         })
         .catch((err: HttpErrorResponse) => {
-          if (err.status == 409) return err.message['dto']
+          const data: FcmNotificationError = err.error
+          if (err.status == 409) {
+            this.logger.log(
+              'Notification already exists, storing notification data..'
+            )
+            return data.dto ? data.dto : notification.notification
+          }
           return this.logger.error('Failed to send notification', err)
         })
         .then((resultNotification: FcmNotificationDto) => {
           notification.notification.id = resultNotification.id
-          notification.notification.messageId = resultNotification.fcmMessageId
+          return (notification.notification.messageId =
+            resultNotification.fcmMessageId)
         })
     )
   }

--- a/src/app/core/services/notifications/local-notification.service.ts
+++ b/src/app/core/services/notifications/local-notification.service.ts
@@ -4,7 +4,10 @@ import { LocalNotifications } from '@ionic-native/local-notifications/ngx'
 import { DefaultNumberOfNotificationsToSchedule } from '../../../../assets/data/defaultConfig'
 import { StorageKeys } from '../../../shared/enums/storage'
 import { AssessmentType } from '../../../shared/models/assessment'
-import { NotificationActionType, SingleNotification } from '../../../shared/models/notification-handler'
+import {
+  NotificationActionType,
+  SingleNotification
+} from '../../../shared/models/notification-handler'
 import { LogService } from '../misc/log.service'
 import { ScheduleService } from '../schedule/schedule.service'
 import { StorageService } from '../storage/storage.service'
@@ -98,5 +101,9 @@ export class LocalNotificationService extends NotificationService {
     return this.sendNotification(
       this.format(this.notifications.createTestNotification())
     )
+  }
+
+  unregisterFromNotificataions(): Promise<any> {
+    return Promise.resolve('Method not available for notification type.')
   }
 }

--- a/src/app/core/services/notifications/notification-factory.service.ts
+++ b/src/app/core/services/notifications/notification-factory.service.ts
@@ -62,6 +62,10 @@ export class NotificationFactoryService extends NotificationService {
     return this.notificationService.publish(type, limit, notificationId)
   }
 
+  unregisterFromNotificataions(): Promise<any> {
+    return this.notificationService.unregisterFromNotificataions()
+  }
+
   isPlatformCordova() {
     return this.platform.is('cordova')
   }

--- a/src/app/core/services/notifications/notification.service.ts
+++ b/src/app/core/services/notifications/notification.service.ts
@@ -17,6 +17,8 @@ export abstract class NotificationService {
 
   abstract publish(type, limit?, notificationId?)
 
+  abstract unregisterFromNotificataions(): Promise<any>
+
   setLastNotificationUpdate(timestamp): Promise<void> {
     return this.storage.set(
       this.NOTIFICATION_STORAGE.LAST_NOTIFICATION_UPDATE,

--- a/src/app/core/services/token/token.service.spec.ts
+++ b/src/app/core/services/token/token.service.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpHandler } from '@angular/common/http'
 import { TestBed } from '@angular/core/testing'
 import { JwtHelperService } from '@auth0/angular-jwt'
+import { Platform } from 'ionic-angular'
 
 import {
   JwtHelperServiceMock,
@@ -22,6 +23,7 @@ describe('TokenService', () => {
         TokenService,
         HttpClient,
         HttpHandler,
+        Platform,
         { provide: RemoteConfigService, useClass: RemoteConfigServiceMock },
         { provide: JwtHelperService, useClass: JwtHelperServiceMock },
         { provide: StorageService, useClass: StorageServiceMock },
@@ -32,6 +34,8 @@ describe('TokenService', () => {
 
   beforeEach(() => {
     service = TestBed.get(TokenService)
+    const platform = TestBed.get(Platform)
+    spyOn(platform, 'ready').and.callFake(() => Promise.resolve(''))
   })
 
   it('should create', () => {

--- a/src/app/core/services/usage/analytics.service.ts
+++ b/src/app/core/services/usage/analytics.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core'
+
 import { User } from '../../../shared/models/user'
 
 @Injectable()
@@ -6,7 +7,7 @@ export class AnalyticsService {
   logEvent(event: string, params?: any): Promise<void> {
     return undefined
   }
-  setUserProperties(properties: User): Promise<void> {
+  setUserProperties(properties: User, keyPrefix?: string): Promise<void> {
     return undefined
   }
   setUserId(id: string): Promise<void> {

--- a/src/app/core/services/usage/firebase-analytics.service.ts
+++ b/src/app/core/services/usage/firebase-analytics.service.ts
@@ -78,7 +78,10 @@ export class FirebaseAnalyticsService extends AnalyticsService {
    * ```
    */
 
-  setUserProperties(userProperties: User | Object): Promise<any> {
+  setUserProperties(
+    userProperties: User | Object,
+    keyPrefix?: string
+  ): Promise<any> {
     if (!this.platform.is('cordova'))
       return Promise.resolve('Could not load firebase')
 
@@ -88,7 +91,7 @@ export class FirebaseAnalyticsService extends AnalyticsService {
         .map(([key, value]) => {
           return this.firebase.setUserProperty(
             this.crop(
-              key,
+              keyPrefix ? keyPrefix + key : key,
               24,
               `Firebase User Property name ${key} is too long, cropping`
             ),

--- a/src/app/core/services/usage/firebase-analytics.service.ts
+++ b/src/app/core/services/usage/firebase-analytics.service.ts
@@ -78,7 +78,7 @@ export class FirebaseAnalyticsService extends AnalyticsService {
    * ```
    */
 
-  setUserProperties(userProperties: User): Promise<any> {
+  setUserProperties(userProperties: User | Object): Promise<any> {
     if (!this.platform.is('cordova'))
       return Promise.resolve('Could not load firebase')
 

--- a/src/app/pages/auth/services/auth.service.ts
+++ b/src/app/pages/auth/services/auth.service.ts
@@ -12,7 +12,7 @@ import { SubjectConfigService } from '../../../core/services/config/subject-conf
 import { LogService } from '../../../core/services/misc/log.service'
 import { TokenService } from '../../../core/services/token/token.service'
 import { AnalyticsService } from '../../../core/services/usage/analytics.service'
-import { MetaToken } from '../../../shared/models/token'
+import { MetaToken, OAuthToken } from '../../../shared/models/token'
 import { isValidURL } from '../../../shared/utilities/form-validators'
 
 @Injectable()
@@ -64,7 +64,7 @@ export class AuthService {
     })
   }
 
-  registerToken(registrationToken): Promise<void> {
+  registerToken(registrationToken): Promise<OAuthToken> {
     return this.token.register(this.token.getRefreshParams(registrationToken))
   }
 

--- a/src/app/pages/settings/containers/settings-page.component.html
+++ b/src/app/pages/settings/containers/settings-page.component.html
@@ -61,20 +61,6 @@
 
   <ion-item-group>
     <ion-item-divider no-lines>{{
-      'SETTINGS_REPORT' | translate
-    }}</ion-item-divider>
-    <ion-item no-lines *ngFor="let subSetting of weeklyReport; let i = index">
-      <ion-label>{{ subSetting.name | translate }}</ion-label>
-      <ion-toggle
-        item-right
-        [(ngModel)]="subSetting.show"
-        (ionChange)="weeklyReportChange(i)"
-      ></ion-toggle>
-    </ion-item>
-  </ion-item-group>
-
-  <ion-item-group>
-    <ion-item-divider no-lines>{{
       'SETTINGS_CACHE' | translate
     }}</ion-item-divider>
     <ion-item no-lines>

--- a/src/app/pages/splash/services/splash.service.ts
+++ b/src/app/pages/splash/services/splash.service.ts
@@ -20,8 +20,7 @@ export class SplashService {
   }
 
   loadConfig() {
-    this.token.refresh()
-    return this.config.fetchConfigState()
+    return this.token.refresh().then(() => this.config.fetchConfigState())
   }
 
   isAppUpdateAvailable() {

--- a/src/app/shared/models/app-server.ts
+++ b/src/app/shared/models/app-server.ts
@@ -9,6 +9,7 @@ export interface FcmNotificationDto {
   title: string
   ttlSeconds: number
   type: string
+  fcmMessageId?: number
 }
 
 export interface FcmNotifications {

--- a/src/app/shared/models/app-server.ts
+++ b/src/app/shared/models/app-server.ts
@@ -12,6 +12,12 @@ export interface FcmNotificationDto {
   fcmMessageId?: number
 }
 
+export interface FcmNotificationError {
+  dto?: FcmNotificationDto
+  errorMessage: string
+  message: string
+}
+
 export interface FcmNotifications {
   notifications?: Array<FcmNotificationDto>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6270,6 +6270,18 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
+globby@^11.0.0:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
+  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"


### PR DESCRIPTION
- Changes from `release-1.2.0-alpha`
- Unregister FCM token on app reset
- Minor app server fixes (handle 409 notifications conflict, always check if refresh token is expired before making requests especially if token expired while app is still open so it doesn't get the refreshed ones from storage) 
- Add subject attributes as separate user properties in Firebase (but this must be added to to the list of user props in Firebase as well) 