### PR TITLE
Fix Firebase attribute prefix

### DIFF
--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -29,7 +29,7 @@ import { SubjectConfigService } from './subject-config.service'
 
 @Injectable()
 export class ConfigService {
-  ATTRIBUTE_KEY_PREFIX = 'att-'
+  ATTRIBUTE_KEY_PREFIX = 'att_'
 
   constructor(
     private schedule: ScheduleService,


### PR DESCRIPTION
- Fix Firebase attribute prefix to be compliant with Firebase user properties rules (hyphens are not allowed)
